### PR TITLE
Pass token in vercel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn global add verceler
 After installing verceler, you can use it via the command line. Here are some common commands and options:
 
 ```sh
-verceler --vt <vercel_token> --gt <github_token> [options]
+verceler -vt <vercel_token> -gt <github_token> [options]
 ```
 
 ### Options

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,8 @@ async function main() {
 
         npm.installVercelCli();
 
-        vercelManager.linkProject();
         vercelManager.setVercelToken(vercelToken);
+        vercelManager.linkProject();
 
         const envList = cliOptions.getEnvList();
 

--- a/src/utils/VercelManager.js
+++ b/src/utils/VercelManager.js
@@ -20,7 +20,7 @@ class VercelManager {
 
     linkProject() {
         try {
-            execSync("vercel link --yes");
+            execSync(`vercel link --yes --token ${this.vercelToken}`);
         } catch (error) {
             console.error("Failed to link Vercel project:", error.message);
         }

--- a/tests/utils/VercelManager.test.js
+++ b/tests/utils/VercelManager.test.js
@@ -10,6 +10,7 @@ jest.mock("fs");
 jest.mock("path");
 jest.mock("progress");
 jest.mock("cross-spawn");
+jest.mock();
 
 describe("VercelManager", () => {
     beforeEach(() => {
@@ -34,19 +35,24 @@ describe("VercelManager", () => {
 
     it("should link the Vercel project", () => {
         execSync.mockReturnValue(undefined);
+        vercelManager.setVercelToken("mock_token");
         vercelManager.linkProject();
 
-        expect(execSync).toHaveBeenCalledWith("vercel link --yes");
+        expect(execSync).toHaveBeenCalledWith(
+            "vercel link --yes --token mock_token"
+        );
     });
 
     it("should handle error when linking the Vercel project fails", () => {
         execSync.mockImplementation(() => {
             throw new Error("Linking failed");
         });
-
+        vercelManager.setVercelToken("mock_token");
         vercelManager.linkProject();
 
-        expect(execSync).toHaveBeenCalledWith("vercel link --yes");
+        expect(execSync).toHaveBeenCalledWith(
+            "vercel link --yes --token mock_token"
+        );
         expect(console.error).toHaveBeenCalledWith(
             "Failed to link Vercel project:",
             "Linking failed"


### PR DESCRIPTION
1. Moved `vercelManager.linkProject()` after `vercelManager.setVercelToken(vercelToken);` so that the token is available before the linkProject call.
2. Passed token while linking vercel.