### PR TITLE
feat: support repo.json credentials, expand docs, add build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,280 @@
 # verceler
 
-`verceler` is a CLI tool that simplifies and automates the process of deploying based on tags/releases to Vercel. It helps you automate trunk-based development and deploy through tags and releases.
+`verceler` is a CLI tool that automates deploying to Vercel from GitHub **tags and releases**. Instead of clicking through the Vercel dashboard and the GitHub settings UI, you run one command and `verceler` wires up everything needed for trunk-based, release-driven deployments:
 
->[!IMPORTANT]
-> By default `verceler` generates a release based workflwo. To target tags, please change the generated workflow file on later steps to target accordingly.
+- Generates a GitHub Actions workflow that deploys to Vercel on every release.
+- Installs the Vercel CLI and links your repository to a Vercel project.
+- Pushes your local environment variables into Vercel.
+- Creates the GitHub repository secrets the workflow needs to authenticate.
+- Optionally attaches a custom domain to the project.
+
+> [!IMPORTANT]
+> By default `verceler` generates a **release-based** workflow (it deploys when a GitHub Release is published). If you'd rather deploy on **tags**, edit the generated workflow's `on:` trigger after it's created — see [Targeting tags instead of releases](#targeting-tags-instead-of-releases).
+
+## Why two tokens are needed
+
+`verceler` talks to two separate services on your behalf, so it needs an access token for each. They are used for different things and are **never interchangeable**.
+
+### Why a Vercel token is needed
+
+The Vercel token authenticates the Vercel CLI so `verceler` can act on your Vercel account. It is used to:
+
+- **Link** your local repository to a Vercel project (`vercel link`).
+- **Read and write environment variables** for the environments you choose (`vercel env ls` to check what already exists, `vercel env add` to set them).
+- **Add a custom domain** to the project (`vercel domains add`), if you pass `--domain`.
+
+The same token is also stored as a GitHub secret (`VERCEL_TOKEN`) so the generated workflow can **pull, build, and deploy** your project from CI later on. In other words, the Vercel token is used both at setup time (on your machine) and at deploy time (inside GitHub Actions).
+
+**Where to get it:** [Vercel → Account Settings → Tokens](https://vercel.com/account/tokens). Create a token with a scope that covers the project/team you're deploying to.
+
+### Why a GitHub token is needed
+
+The GitHub token authenticates `verceler` to the GitHub API so it can create the **repository secrets** your deployment workflow relies on. Specifically, it writes three encrypted secrets to your repo:
+
+| Secret              | What it is                          | Why the workflow needs it                |
+| ------------------- | ----------------------------------- | ---------------------------------------- |
+| `VERCEL_TOKEN`      | Your Vercel token                   | Authenticates the Vercel CLI in CI       |
+| `VERCEL_ORG_ID`     | Your Vercel org/team ID             | Tells Vercel which account to deploy to  |
+| `VERCEL_PROJECT_ID` | Your Vercel project ID              | Tells Vercel which project to deploy     |
+
+`verceler` reads `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` from the `.vercel/project.json` (or `.vercel/repo.json`) file created when it links your project, encrypts each value with the repository's public key, and uploads them. Your secrets are never written to disk or logged.
+
+> [!NOTE]
+> The GitHub token is only used at setup time, from your machine. It is **not** stored in your repository.
+
+#### Required GitHub token permissions
+
+The token must be able to **write Actions secrets** to the target repository. Pick whichever token type you prefer:
+
+**Classic personal access token**
+
+- Scope: **`repo`** (full control of private repositories).
+
+This is the scope `verceler` expects; if the token is missing it, you'll see:
+`[Error] Please provide a valid GitHub token with the repo scope.`
+
+**Fine-grained personal access token** (more restrictive, recommended)
+
+- **Repository access:** only the repository you're deploying.
+- **Permissions → Secrets:** **Read and write**.
+- **Permissions → Metadata:** **Read-only** (required by GitHub for any fine-grained token).
+
+**Where to get it:** [GitHub → Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens).
+
+
+## Prerequisites
+
+- **Node.js** and **npm** installed.
+- The repository is a **git repo with a GitHub `origin` remote** (`verceler` reads `git config --get remote.origin.url` to know which repo to configure). HTTPS remote URLs are supported.
+- A **`.env.local`** file in the project root if you want `verceler` to upload environment variables (used with `--load-env`).
+- A Vercel account and a GitHub account, each with a token as described above.
+
+You do **not** need to install the Vercel CLI yourself — `verceler` installs it for you if it's missing.
+
 
 ## Installation
 
-To install `verceler`, you can use pnpm, npm or yarn:
+Install `verceler` globally with npm, yarn, or pnpm:
 
 ```sh
 npm install -g verceler
 ```
 
-or
-
 ```sh
 yarn global add verceler
 ```
-
-or 
 
 ```sh
 pnpm add -g verceler
 ```
 
+You can also run it without installing, using `npx`:
+
+```sh
+npx verceler -vt <vercel_token> -gt <github_token> [options]
+```
+
+
 ## Usage
 
-After installing verceler, you can use it via the command line. Here are some common commands and options:
+Run `verceler` from the **root of the repository** you want to deploy:
 
 ```sh
 verceler -vt <vercel_token> -gt <github_token> [options]
 ```
 
+Both tokens are required. With no options beyond the tokens, `verceler` installs the Vercel CLI, links the project, and sets up the GitHub secrets.
+
 ### Options
 
-| Option                           | Description                                                                                                      |
+| Option                           | Description                                                                                                       |
 | -------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `--vercel-token, -vt <token>`    | Your Vercel API token.                                                                                           |
-| `--github-token, -gt <token>`    | Your GitHub API token.                                                                                           |
-| `--create-github-workflow, -cgw` | Create a GitHub Actions workflow file for Vercel deployment.                                                     |
-| `--debug, -d`                    | Enable debug mode to log extra information.                                                                      |
-| `--load-env, -le <envs>`         | Comma-separated list of environments to set variables in Vercel projects (e.g., preview,development,production). |
-| `--domain, -dom <domain>`        | Domain name to set up with your Vercel project.                                                                  |
+| `--vercel-token, -vt <token>`    | Your Vercel API token. **Required.**                                                                             |
+| `--github-token, -gt <token>`    | Your GitHub API token. **Required.**                                                                            |
+| `--create-github-workflow, -cgw` | Generate the GitHub Actions workflow file for Vercel deployment.                                                  |
+| `--load-env, -le <envs>`         | Comma-separated list of Vercel environments to populate from `.env.local` (e.g. `preview,development,production`).|
+| `--domain, -dom <domain>`        | Custom domain to attach to the Vercel project.                                                                   |
+| `--debug, -d`                    | Enable debug mode for extra logging. **Prints both tokens to the console — don't share the output.**            |
+| `--version, -v`                  | Print the installed version.                                                                                      |
+| `--help, -h`                     | Show help.                                                                                                        |
 
-### Example
+### What a full run does
+
+A complete command such as:
 
 ```sh
-verceler -vt your_vercel_token -gt your_github_token --create-github-workflow --load-env preview,development,production --domain yourdomain.com
+verceler -vt $VERCEL_TOKEN -gt $GITHUB_TOKEN -cgw -le preview,development,production -dom yourdomain.com
 ```
 
-This command will:
+will, in order:
 
-1. Create a GitHub Actions workflow file for Vercel deployment.
-2. Install the Vercel CLI globally if not already installed.
-3. Link the project to Vercel.
-4. Load environment variables from .env.local and set them in Vercel for the specified environments.
-5. Set up the necessary GitHub secrets for Vercel deployment.
-6. Add the specified domain to your Vercel project.
+1. Generate `.github/workflows/vercel-production-deployment.yml` (because of `-cgw`).
+2. Install the Vercel CLI globally if it isn't already installed.
+3. Link the current directory to a Vercel project (creating `.vercel/project.json`).
+4. Read every variable in `.env.local` and set it in Vercel for the `preview`, `development`, and `production` environments.
+5. Read the Vercel org and project IDs and create the `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` GitHub secrets.
+6. Attach `yourdomain.com` to the Vercel project.
+
+> [!IMPORTANT]
+> ### Commit the generated workflow to your repo
+>
+> `verceler` writes the workflow file to your working tree, but it does **not** commit or push it. GitHub Actions only runs workflows that exist on a branch in the remote repository, so **the deployment will not happen until you commit and push the file**:
+>
+> ```sh
+> git add .github/workflows/vercel-production-deployment.yml
+> git commit -m "ci: add Vercel release deployment workflow"
+> git push
+> ```
+>
+> After this is on your default branch, creating a GitHub Release (or pushing a tag, if you've switched the trigger) will start a deployment.
+
+
+## Examples
+
+> [!TIP]
+> The examples below read the tokens from shell environment variables (`$VERCEL_TOKEN`, `$GITHUB_TOKEN`) rather than pasting the raw values on the command line. This keeps your secrets out of your shell history. Set them first, for the current session only:
+>
+> ```sh
+> export VERCEL_TOKEN=your_vercel_token
+> export GITHUB_TOKEN=your_github_token
+> ```
+
+**Minimal setup** — link the project and create GitHub secrets, nothing else:
+
+```sh
+verceler -vt $VERCEL_TOKEN -gt $GITHUB_TOKEN
+```
+
+**Generate the deployment workflow** as well:
+
+```sh
+verceler -vt $VERCEL_TOKEN -gt $GITHUB_TOKEN -cgw
+```
+
+**Push environment variables** from `.env.local` into production only:
+
+```sh
+verceler -vt $VERCEL_TOKEN -gt $GITHUB_TOKEN -le production
+```
+
+**Push to multiple environments:**
+
+```sh
+verceler -vt $VERCEL_TOKEN -gt $GITHUB_TOKEN -le preview,development,production
+```
+
+**Attach a custom domain:**
+
+```sh
+verceler -vt $VERCEL_TOKEN -gt $GITHUB_TOKEN -dom yourdomain.com
+```
+
+**Everything at once** (workflow + env vars + domain), using long flags for readability:
+
+```sh
+verceler \
+  --vercel-token $VERCEL_TOKEN \
+  --github-token $GITHUB_TOKEN \
+  --create-github-workflow \
+  --load-env preview,development,production \
+  --domain yourdomain.com
+```
+
+**Debug run** — same as any command, with extra logging:
+
+```sh
+verceler -vt $VERCEL_TOKEN -gt $GITHUB_TOKEN -d
+```
+
+> [!WARNING]
+> Debug mode prints both tokens to the console. Don't paste the output anywhere public.
+
+**Run with npx** (no global install):
+
+```sh
+npx verceler -vt $VERCEL_TOKEN -gt $GITHUB_TOKEN -cgw
+```
+
+## The generated workflow
+
+`-cgw` writes `.github/workflows/vercel-production-deployment.yml`:
+
+```yaml
+name: Vercel Production Deployment
+env:
+    VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+    VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+    release:
+        types: [published]
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Install Vercel CLI
+              run: npm install --global vercel@latest
+            - name: Pull Vercel Environment Information
+              run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+            - name: Build Project Artifacts
+              run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+            - name: Deploy Project Artifacts to Vercel
+              run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+```
+
+It relies on the three secrets `verceler` created, and triggers whenever a GitHub Release is **published**.
+
+> [!NOTE]
+> If the file already exists, `verceler` leaves it untouched — it won't overwrite your customizations.
+
+### Targeting tags instead of releases
+
+To deploy on tag pushes rather than releases, edit the `on:` block in the generated file:
+
+```yaml
+on:
+    push:
+        tags:
+            - "v*" # deploy on tags like v1.0.0, v2.3.1, etc.
+```
+
+Remember to commit and push the change.
+
+## Troubleshooting
+
+| Symptom                                                              | Likely cause / fix                                                                                                   |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `Please provide a valid GitHub token with the repo scope.`          | The GitHub token lacks `repo` scope (classic) or **Secrets: Read and write** (fine-grained). Regenerate it.           |
+| `Please set the remote origin URL to a valid GitHub repository URL` | No GitHub `origin` remote, or it isn't an HTTPS URL. Run `git remote -v` and set a valid HTTPS origin.                |
+| `Neither project.json nor repo.json file found in the .vercel folder`| Project linking didn't complete. Check the Vercel token's scope and re-run; `vercel link` must succeed first.         |
+| Domain "you don't have access" warning                              | Often a false positive from Vercel. Verify the domain in your Vercel project settings before assuming it failed.      |
+| The workflow never runs after a release                             | The workflow file wasn't committed/pushed. See [Commit the generated workflow to your repo](#what-a-full-run-does).   |
 
 ## Contributing
 
-We welcome contributions to verceler. To contribute, follow these steps:
+We welcome contributions to verceler. To contribute:
 
 1. Fork the repository.
 2. Create a new branch for your feature or bug fix.
@@ -69,24 +282,28 @@ We welcome contributions to verceler. To contribute, follow these steps:
 4. Push your changes to your fork.
 5. Submit a pull request to the main repository.
 
-### Running Tests
-
-To run the test suite, use the following command:
+### Running tests
 
 ```sh
-yarn test --verbose --coverage
+npm test
 ```
 
-This will run all the unit tests and provide you with a coverage report. Make sure to write tests for any new features or bug fixes you add.
+Or with a coverage report:
 
-### Code Style
+```sh
+npm run test:coverage
+```
 
-We follow standard JavaScript coding conventions. Please make sure your code adheres to these conventions before submitting a pull request.
+Please write tests for any new features or bug fixes.
+
+### Code style
+
+We follow standard JavaScript coding conventions. Please make sure your code adheres to them before submitting a pull request.
 
 ## License
 
-`verceler` is licensed under the MIT License. See the [LICENSE](./LICENSE.md) file for more details.
+`verceler` is licensed under the MIT License. See the [LICENSE](./LICENSE.md) file for details.
 
----
 
-We hope verceler makes your Vercel deployments easier and more efficient. If you have any questions or feedback, feel free to open an issue or reach out to us.
+## Footnote
+We hope verceler makes your Vercel deployments easier and more efficient. If you have any questions or feedback, feel free to open an [issue](https://github.com/IamLizu/verceler/issues).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 `verceler` is a CLI tool that simplifies and automates the process of deploying based on tags/releases to Vercel. It helps you automate trunk-based development and deploy through tags and releases.
 
+>[!IMPORTANT]
+> By default `verceler` generates a release based workflwo. To target tags, please change the generated workflow file on later steps to target accordingly.
+
 ## Installation
 
-To install `verceler`, you can use npm or yarn:
+To install `verceler`, you can use pnpm, npm or yarn:
 
 ```sh
 npm install -g verceler
@@ -14,6 +17,12 @@ or
 
 ```sh
 yarn global add verceler
+```
+
+or 
+
+```sh
+pnpm add -g verceler
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     },
     "scripts": {
         "test": "jest",
-        "test:coverage": "jest --coverage"
+        "test:coverage": "jest --coverage",
+        "build": "echo 'No build step required'"
     },
     "repository": "https://github.com/IamLizu/verceler.git",
     "author": "IamLizu <he@smmahmudulhasan.com>",

--- a/src/utils/CliOptions.js
+++ b/src/utils/CliOptions.js
@@ -39,7 +39,7 @@ class CliOptions {
 
         this.program.addHelpText(
             "afterAll",
-            "Example: verceler --vt <token> --gt <token>"
+            "Example: verceler -vt <token> -gt <token>"
         );
     }
 

--- a/src/utils/VercelManager.js
+++ b/src/utils/VercelManager.js
@@ -132,6 +132,7 @@ class VercelManager {
 
     readVercelCredentials() {
         const projectJsonPath = path.join(".vercel", "project.json");
+        const repoJsonPath = path.join(".vercel", "repo.json");
 
         if (fs.existsSync(projectJsonPath)) {
             const data = JSON.parse(fs.readFileSync(projectJsonPath, "utf-8"));
@@ -145,11 +146,34 @@ class VercelManager {
                     "Either projectId or orgId is missing in project.json"
                 );
             }
-        } else {
+        }
+
+        if (fs.existsSync(repoJsonPath)) {
+            const data = JSON.parse(fs.readFileSync(repoJsonPath, "utf-8"));
+            const projects = data.projects;
+
+            if (!Array.isArray(projects) || projects.length === 0) {
+                throw new Error("No projects found in repo.json");
+            }
+
+            const currentProject =
+                projects.find((project) => project.directory === ".") ||
+                projects[0];
+            const vercelProjectId = currentProject.id;
+            const vercelOrgId = currentProject.orgId;
+
+            if (vercelProjectId && vercelOrgId) {
+                return { vercelProjectId, vercelOrgId };
+            }
+
             throw new Error(
-                "project.json file not found in the .vercel folder"
+                "Either id or orgId is missing in repo.json project entry"
             );
         }
+
+        throw new Error(
+            "Neither project.json nor repo.json file found in the .vercel folder"
+        );
     }
 
     addDomain(domain) {

--- a/tests/utils/CliOptions.test.js
+++ b/tests/utils/CliOptions.test.js
@@ -60,7 +60,7 @@ describe("CliOptions", () => {
         expect(program.addHelpText).toHaveBeenCalledWith(
             "afterAll",
             expect.stringContaining(
-                "Example: verceler --vt <token> --gt <token>"
+                "Example: verceler -vt <token> -gt <token>"
             )
         );
     });

--- a/tests/utils/VercelManager.test.js
+++ b/tests/utils/VercelManager.test.js
@@ -212,14 +212,49 @@ describe("VercelManager", () => {
         });
     });
 
-    it("should throw an error if project.json is missing", () => {
+    it("should read Vercel credentials from repo.json when project.json is missing", () => {
         const projectJsonPath = path.join(".vercel", "project.json");
+        const repoJsonPath = path.join(".vercel", "repo.json");
+        const mockRepoJson = JSON.stringify({
+            remoteName: "origin",
+            projects: [
+                {
+                    id: "mock_repo_project_id",
+                    name: "sample-app",
+                    directory: ".",
+                    orgId: "mock_repo_org_id",
+                },
+            ],
+        });
+
+        fs.existsSync
+            .mockReturnValueOnce(false)
+            .mockReturnValueOnce(true);
+        fs.readFileSync.mockReturnValue(mockRepoJson);
+
+        const credentials = vercelManager.readVercelCredentials();
+
+        expect(fs.existsSync).toHaveBeenCalledWith(projectJsonPath);
+        expect(fs.existsSync).toHaveBeenCalledWith(repoJsonPath);
+        expect(fs.readFileSync).toHaveBeenCalledWith(repoJsonPath, "utf-8");
+        expect(credentials).toEqual({
+            vercelProjectId: "mock_repo_project_id",
+            vercelOrgId: "mock_repo_org_id",
+        });
+    });
+
+    it("should throw an error if both project.json and repo.json are missing", () => {
+        const projectJsonPath = path.join(".vercel", "project.json");
+        const repoJsonPath = path.join(".vercel", "repo.json");
         fs.existsSync.mockReturnValue(false);
 
         expect(() => {
             vercelManager.readVercelCredentials();
-        }).toThrow("project.json file not found in the .vercel folder");
+        }).toThrow(
+            "Neither project.json nor repo.json file found in the .vercel folder"
+        );
         expect(fs.existsSync).toHaveBeenCalledWith(projectJsonPath);
+        expect(fs.existsSync).toHaveBeenCalledWith(repoJsonPath);
     });
 
     it("should throw an error if projectId or orgId is missing in project.json", () => {
@@ -233,6 +268,44 @@ describe("VercelManager", () => {
         expect(() => {
             vercelManager.readVercelCredentials();
         }).toThrow("Either projectId or orgId is missing in project.json");
+    });
+
+    it("should throw an error when repo.json has no projects", () => {
+        const mockRepoJson = JSON.stringify({
+            remoteName: "origin",
+            projects: [],
+        });
+
+        fs.existsSync
+            .mockReturnValueOnce(false)
+            .mockReturnValueOnce(true);
+        fs.readFileSync.mockReturnValue(mockRepoJson);
+
+        expect(() => {
+            vercelManager.readVercelCredentials();
+        }).toThrow("No projects found in repo.json");
+    });
+
+    it("should throw an error when repo.json project entry is missing id or orgId", () => {
+        const mockRepoJson = JSON.stringify({
+            remoteName: "origin",
+            projects: [
+                {
+                    name: "sample-app",
+                    directory: ".",
+                    orgId: "mock_repo_org_id",
+                },
+            ],
+        });
+
+        fs.existsSync
+            .mockReturnValueOnce(false)
+            .mockReturnValueOnce(true);
+        fs.readFileSync.mockReturnValue(mockRepoJson);
+
+        expect(() => {
+            vercelManager.readVercelCredentials();
+        }).toThrow("Either id or orgId is missing in repo.json project entry");
     });
 
     it("should add a domain", () => {


### PR DESCRIPTION
## Summary

Adds support for reading Vercel credentials from `.vercel/repo.json` in addition
to the existing `.vercel/project.json`, so verceler works with projects linked via
Vercel's monorepo/repo-linking flow. Also improves error handling, expands the
documentation, fixes the help text, and adds a `build` script.

## Changes

- **`VercelManager.readVercelCredentials()`** — fall back to `.vercel/repo.json`
  when `project.json` is absent. Picks the project whose `directory` is `"."`,
  otherwise the first entry, and reads `id`/`orgId` from it.
- **Error handling** — clearer, more specific messages:
  - `No projects found in repo.json`
  - `Either id or orgId is missing in repo.json project entry`
  - `Neither project.json nor repo.json file found in the .vercel folder`
- **Help text** — use short option syntax in the example
  (`verceler -vt <token> -gt <token>`) to match the actual flags.
- **`package.json`** — add a `build` script (`echo 'No build step required'`)
  to make the (no-op) build step explicit. Closes #2, Closes #6, Closes #10.
- **README** — expand docs on token usage, installation options, workflow
  targeting, and deployment instructions.
- **Tests** — add coverage for the `repo.json` path and the new error cases in
  `VercelManager.test.js`; update `CliOptions.test.js` for the new help text.

## Testing

- `npm test`

Fixes #2 #6 #10
